### PR TITLE
remove member-variable-declaration rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -59,8 +59,7 @@
         "typedef": [
             true,
             "call-signature",
-            "property-declaration",
-            "member-variable-declaration"
+            "property-declaration"
         ],
         "use-strict": [
             false


### PR DESCRIPTION
do not require property type when it is initialized